### PR TITLE
Include <signal.h>

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <errno.h>
 #include <getopt.h>
+#include <signal.h>
 
 #include "sieve.h"
 #include "main.h"


### PR DESCRIPTION
Get the source code to compile. Avoids the following errors:

```
src/main.c: In function ‘main’:
src/main.c:40:5: error: implicit declaration of function ‘signal’ [-Werror=implicit-function-declaration]
     signal(SIGINT, &interrupt);
     ^~~~~~
src/main.c:40:12: error: ‘SIGINT’ undeclared (first use in this function)
     signal(SIGINT, &interrupt);
            ^~~~~~
```